### PR TITLE
Creating Store with Reducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,24 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 import './index.css';
 import App from './containers/App.js';
 import reportWebVitals from './reportWebVitals';
 import 'tachyons';
+import {searchRobots} from './reducers.js';
+
+const store = createStore(searchRobots);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    {/*Passing the store to the Provider which will handle passing it to all descendant components
+    instead of having to pass it to each component individually.*/}
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>
 );
 

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,5 +1,5 @@
 // Set the initial state, SINGLE SOURCE OF TRUTH.
-import {SET_SEARCH_FIELD} from "src/constants.js";
+import {SET_SEARCH_FIELD} from './constants.js';
 
 const initialState = {
   robots: [],


### PR DESCRIPTION
Using provider from react-redux to wrap the app component and be able to pass it the store with its reducers. Using createStore (for learning purposes) to initialize the store with the root reducer.